### PR TITLE
rename TangleGraph.init to TangleGraph.add

### DIFF
--- a/sample/app/src/androidTest/kotlin/tangle/sample/app/support/TestTangleApplication.kt
+++ b/sample/app/src/androidTest/kotlin/tangle/sample/app/support/TestTangleApplication.kt
@@ -35,7 +35,7 @@ class TestTangleApplication : Application() {
       .create(this)
 
     Components.add(component)
-    TangleGraph.init(component)
+    TangleGraph.add(component)
 
     Components.get<TestTangleApplicationComponent>().inject(this)
 

--- a/sample/app/src/main/kotlin/tangle/sample/app/TangleApplication.kt
+++ b/sample/app/src/main/kotlin/tangle/sample/app/TangleApplication.kt
@@ -34,7 +34,7 @@ class TangleApplication : Application() {
       .create(this)
 
     Components.add(component)
-    TangleGraph.init(component)
+    TangleGraph.add(component)
 
     Components.get<TangleApplicationComponent>()
       .appPlugins

--- a/tangle-api/api/tangle-api.api
+++ b/tangle-api/api/tangle-api.api
@@ -3,6 +3,7 @@ public abstract interface annotation class tangle/inject/InternalTangleApi : jav
 
 public final class tangle/inject/TangleGraph {
 	public static final field INSTANCE Ltangle/inject/TangleGraph;
+	public final fun add (Ljava/lang/Object;)V
 	public final fun init (Ljava/lang/Object;)V
 }
 

--- a/tangle-api/src/main/kotlin/tangle/inject/TangleGraph.kt
+++ b/tangle-api/src/main/kotlin/tangle/inject/TangleGraph.kt
@@ -38,11 +38,31 @@ public object TangleGraph {
    *
    * This should be initialized as soon as possible after initializing the AppComponent.
    *
+   * This function has been renamed to `add`.  This "init" version will be removed soon.
+   *
    * @sample tangle.inject.samples.TangleGraphSample.tangleGraphSample
    * @param component the application-scoped Dagger component
    * @since 0.10.0
    */
+  @Deprecated(
+    "use TangleGraph.add(...) instead",
+    ReplaceWith("TangleGraph.add(component)", "tangle.inject.TangleGraph")
+  )
   public fun init(component: Any) {
+    add(component)
+  }
+
+  /**
+   * Sets a reference to the application's Dagger graph,
+   * so that it can be accessed by internal tooling.
+   *
+   * This should be initialized as soon as possible after initializing the AppComponent.
+   *
+   * @sample tangle.inject.samples.TangleGraphSample.tangleGraphSample
+   * @param component the application-scoped Dagger component
+   * @since 0.13.0
+   */
+  public fun add(component: Any) {
     components.add(component)
   }
 

--- a/tangle-api/src/test/kotlin/tangle/inject/samples/TangleGraphSample.kt
+++ b/tangle-api/src/test/kotlin/tangle/inject/samples/TangleGraphSample.kt
@@ -32,7 +32,7 @@ class TangleGraphSample {
         val appComponent = DaggerAppComponent.factory()
           .create(this)
 
-        TangleGraph.init(appComponent)
+        TangleGraph.add(appComponent)
       }
     }
   }

--- a/tangle-viewmodel-api/src/main/kotlin/tangle/viewmodel/TangleGraph.kt
+++ b/tangle-viewmodel-api/src/main/kotlin/tangle/viewmodel/TangleGraph.kt
@@ -32,9 +32,9 @@ public object TangleGraph {
   @Deprecated(
     message = "TangleGraph has been moved to `tangle.inject.TangleGraph`.  " +
       "This breadcrumb object will be removed in a future version of Tangle.",
-    replaceWith = ReplaceWith("TangleGraph.init(any)", "tangle.inject.TangleGraph")
+    replaceWith = ReplaceWith("TangleGraph.add(any)", "tangle.inject.TangleGraph")
   )
   public fun init(any: Any) {
-    NewTangleGraph.init(any)
+    NewTangleGraph.add(any)
   }
 }

--- a/tangle-viewmodel-api/src/test/kotlin/tangle/viewmodel/TangleGraphTest.kt
+++ b/tangle-viewmodel-api/src/test/kotlin/tangle/viewmodel/TangleGraphTest.kt
@@ -60,7 +60,7 @@ class TangleGraphTest : BaseTest() {
     val component = daggerAppComponent.createFunction()
       .invoke(null)!!
 
-    TangleGraph.init(component)
+    TangleGraph.add(component)
 
     val keys = TangleGraph.get<TangleViewModelComponent>()
       .tangleViewModelKeysSubcomponentFactory
@@ -93,7 +93,7 @@ class TangleGraphTest : BaseTest() {
     val component = daggerAppComponent.createFunction()
       .invoke(null)!!
 
-    TangleGraph.init(component)
+    TangleGraph.add(component)
 
     val factory = TangleGraph.get<TangleViewModelComponent>()
       .tangleViewModelMapSubcomponentFactory

--- a/tangle-work-api/src/test/kotlin/tangle/work/WorkerIntegrationTest.kt
+++ b/tangle-work-api/src/test/kotlin/tangle/work/WorkerIntegrationTest.kt
@@ -120,7 +120,7 @@ class WorkerIntegrationTest : BaseTest() {
     val component = daggerAppComponent.createFunction()
       .invoke(null)!!
 
-    TangleGraph.init(component)
+    TangleGraph.add(component)
 
     val workerFactory = TangleGraph.get<WorkerComponent>()
       .tangleWorkerFactory

--- a/tangle-work-api/src/test/kotlin/tangle/work/samples/TangleWorkerFactorySample.kt
+++ b/tangle-work-api/src/test/kotlin/tangle/work/samples/TangleWorkerFactorySample.kt
@@ -38,7 +38,7 @@ class TangleWorkerFactorySample {
         val myAppComponent = DaggerAppComponent.factory()
           .create(this)
 
-        TangleGraph.init(myAppComponent)
+        TangleGraph.add(myAppComponent)
 
         // inject your application class after initializing TangleGraph
         (myAppComponent as MyApplicationComponent).inject(this)

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -199,7 +199,7 @@ dependencies {
 ## Setting up the Tangle graph
 
 In order to connect Tangle to your application-scoped Dagger component,
-call `TangleGraph.init(...)` immediately after creating the component.
+call `TangleGraph.add(...)` immediately after creating the component.
 
 ```kotlin
 import android.app.Application
@@ -213,7 +213,7 @@ class MyApplication : Application() {
     val myAppComponent = DaggerMyAppComponent.factory()
       .create(this)
 
-    TangleGraph.init(myAppComponent)
+    TangleGraph.add(myAppComponent)
   }
 }
 ```

--- a/website/docs/viewModels/viewModels.md
+++ b/website/docs/viewModels/viewModels.md
@@ -36,7 +36,7 @@ class MyApplication : Application() {
     val myAppComponent = DaggerAppComponent.factory()
       .create(this)
 
-    TangleGraph.init(myAppComponent)
+    TangleGraph.add(myAppComponent)
   }
 }
 ```

--- a/website/docs/workManager/workManager.md
+++ b/website/docs/workManager/workManager.md
@@ -50,7 +50,7 @@ class MyApplication : Application(), Configuration.Provider {
     val myAppComponent = DaggerAppComponent.factory()
       .create(this)
 
-    TangleGraph.init(myAppComponent)
+    TangleGraph.add(myAppComponent)
 
     // inject your application class after initializing TangleGraph
     (myAppComponent as MyApplicationComponent).inject(this)


### PR DESCRIPTION
This function needs to be called for subcomponents as well, after you could consider the TangleGraph to have been "initialized".