### PR TITLE
fix the regex for parsing applied plugin versions

### DIFF
--- a/buildSrc/src/main/kotlin/website.gradle.kts
+++ b/buildSrc/src/main/kotlin/website.gradle.kts
@@ -99,7 +99,7 @@ fun File.updateTangleVersionRef(version: String) {
   val group = project.extra.properties["GROUP"] as String
 
   val pluginRegex =
-    """^([^'"\n]*['"])$group[^'"]*(['"].*) version (['"])[^'"]*(['"])${'$'}""".toRegex()
+    """^([^'"\n]*['"])$group[^'"]*(['"].*) version (['"])[^'"]*(['"].*)${'$'}""".toRegex()
   val moduleRegex = """^([^'"\n]*['"])$group:([^:]*):[^'"]*(['"].*)${'$'}""".toRegex()
 
   val newText = readText()

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -45,7 +45,7 @@ pluginManagement {
 plugins {
   // add Tangle and Anvil versions to the project's classpath
   id("com.squareup.anvil") version <anvil_version> apply false
-  id("com.rickbusarow.tangle") version "0.13.0" apply false
+  id("com.rickbusarow.tangle") version "0.13.2" apply false
 }
 ```
 
@@ -92,7 +92,7 @@ pluginManagement {
 plugins {
   // add Tangle and Anvil versions to the project's classpath
   id 'com.squareup.anvil' version <anvil_version> apply false
-  id 'com.rickbusarow.tangle' version "0.13.0" apply false
+  id 'com.rickbusarow.tangle' version "0.13.2" apply false
 }
 ```
 


### PR DESCRIPTION
It was failing when a markdown sample applied the plugin, but added `apply false` afterwards.