### PR TITLE
remove the `-q` switch from ktlintCheck in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         if: github.event.pull_request.head.repo.full_name != github.repository
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: ktlintCheck -q
+          arguments: ktlintCheck
           cache-read-only: false
 
   versioning:


### PR DESCRIPTION
This is a relic of an old bug in the plugin which generated enormous amounts of spam.  The bug has been fixed for a while now.