### PR TITLE
fix javadoc generation in release builds

### DIFF
--- a/buildSrc/src/main/kotlin/dokka.gradle.kts
+++ b/buildSrc/src/main/kotlin/dokka.gradle.kts
@@ -17,65 +17,52 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.tasks.KtLintCheckTask
 import org.jlleitschuh.gradle.ktlint.tasks.KtLintFormatTask
 
-apply(plugin = "org.jetbrains.dokka")
+plugins {
+  id("org.jetbrains.dokka")
+}
 
-subprojects {
+tasks
+  .withType<org.jetbrains.dokka.gradle.AbstractDokkaLeafTask>()
+  .configureEach {
 
-  val proj = this
+    // Dokka doesn't support configuration caching
+    notCompatibleWithConfigurationCache("Dokka doesn't support configuration caching")
 
-  val includeSubproject = when {
-    path.endsWith("tests") -> false
-    proj.parent?.path == ":sample" -> false
-    else -> File("${proj.projectDir}/src").exists()
-  }
+    // Dokka uses their outputs but doesn't explicitly depend upon them.
+    mustRunAfter(tasks.withType(KotlinCompile::class.java))
+    mustRunAfter(tasks.withType(KtLintCheckTask::class.java))
+    mustRunAfter(tasks.withType(KtLintFormatTask::class.java))
 
-  if (includeSubproject) {
-    apply(plugin = "org.jetbrains.dokka")
+    val fullModuleName = project.path.removePrefix(":")
 
-    proj.tasks
-      .withType<org.jetbrains.dokka.gradle.AbstractDokkaLeafTask>()
-      .configureEach {
+    moduleName.set(fullModuleName)
 
-        // Dokka doesn't support configuration caching
-        notCompatibleWithConfigurationCache("Dokka doesn't support configuration caching")
+    dokkaSourceSets {
 
-        // Dokka uses their outputs but doesn't explicitly depend upon them.
-        mustRunAfter(tasks.withType(KotlinCompile::class.java))
-        mustRunAfter(tasks.withType(KtLintCheckTask::class.java))
-        mustRunAfter(tasks.withType(KtLintFormatTask::class.java))
+      getByName("main") {
 
-        val fullModuleName = project.path.removePrefix(":")
-
-        moduleName.set(fullModuleName)
-
-        dependsOn(allprojects.mapNotNull { it.tasks.findByName("compileKotlin") })
-
-        dokkaSourceSets {
-
-          getByName("main") {
-
-            samples.setFrom(
-              fileTree(proj.projectDir) {
-                include("**/samples/**")
-              }
-            )
-
-            if (File("${proj.projectDir}/README.md").exists()) {
-              includes.from(files("${proj.projectDir}/README.md"))
-            }
-
-            sourceLink {
-              localDirectory.set(file("src/main"))
-
-              val modulePath = proj.path.replace(":", "/").replaceFirst("/", "")
-
-              // URL showing where the source code can be accessed through the web browser
-              remoteUrl.set(uri("https://github.com/RBusarow/Tangle/blob/main/$modulePath/src/main").toURL())
-              // Suffix which is used to append the line number to the URL. Use #L for GitHub
-              remoteLineSuffix.set("#L")
-            }
+        samples.setFrom(
+          fileTree(projectDir) {
+            include("**/samples/**")
           }
+        )
+
+        val readmeFile = file("$projectDir/README.md")
+
+        if (readmeFile.exists()) {
+          includes.from(readmeFile)
+        }
+
+        sourceLink {
+          localDirectory.set(file("src/main"))
+
+          val modulePath = path.replace(":", "/").replaceFirst("/", "")
+
+          // URL showing where the source code can be accessed through the web browser
+          remoteUrl.set(uri("https://github.com/RBusarow/Tangle/blob/main/$modulePath/src/main").toURL())
+          // Suffix which is used to append the line number to the URL. Use #L for GitHub
+          remoteLineSuffix.set("#L")
         }
       }
-  }
+    }
 }

--- a/buildSrc/src/main/kotlin/knit.gradle.kts
+++ b/buildSrc/src/main/kotlin/knit.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Rick Busarow
+ * Copyright (C) 2022 Rick Busarow
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,11 +12,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-apply(plugin = "kotlinx-knit")
+plugins {
+  id("kotlinx-knit")
+}
 
 extensions.configure<kotlinx.knit.KnitPluginExtension> {
+  moduleRoots = listOf(".")
 
+  moduleDocs = "build/dokka/htmlMultiModule"
+  dokkaMultiModuleRoot = "build/dokka/htmlMultiModule"
+  moduleMarkers = listOf("build.gradle", "build.gradle.kts")
+  siteRoot = "https://rbusarow.github.io/Tangle/api/"
+}
+
+// Build API docs for all modules with dokka before running Knit
+tasks.withType<kotlinx.knit.KnitTask>().configureEach {
+  notCompatibleWithConfigurationCache("")
+  dependsOn("dokkaHtmlMultiModule")
   rootDir = rootProject.rootDir
 
   files = fileTree(project.rootDir) {
@@ -32,16 +44,4 @@ extensions.configure<kotlinx.knit.KnitPluginExtension> {
       "**/.gradle/**"
     )
   }
-
-  moduleRoots = listOf(".")
-
-  moduleDocs = "build/dokka"
-  moduleMarkers = listOf("build.gradle", "build.gradle.kts")
-  siteRoot = "https://rbusarow.github.io/Tangle/api/"
 }
-
-// Build API docs for all modules with dokka before running Knit
-tasks.withType<kotlinx.knit.KnitTask>()
-  .configureEach {
-    dependsOn("dokkaHtmlMultiModule")
-  }

--- a/buildSrc/src/main/kotlin/published.gradle.kts
+++ b/buildSrc/src/main/kotlin/published.gradle.kts
@@ -31,6 +31,7 @@ import kotlin.reflect.KProperty
 
 plugins {
   id("com.vanniktech.maven.publish.base")
+  id("dokka")
   id("dependency-guard")
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,8 @@ coil = "2.1.0"
 dependencyAnalysis = "1.10.0"
 dispatch = "1.0.0-beta10"
 detekt = "1.21.0"
-dokka = "1.7.10"
+# can't update Dokka until AGP 7.3+ https://github.com/Kotlin/dokka/issues/2472
+dokka = "1.6.10"
 dropbox-dependencyGuard = "0.3.1"
 gradleDoctor = "0.8.1"
 groovy = "3.0.12"
@@ -171,6 +172,7 @@ coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 coil-core = { module = "io.coil-kt:coil", version.ref = "coil" }
 coil-gif = { module = "io.coil-kt:coil-gif", version.ref = "coil" }
 
+dokka-core = { module = "org.jetbrains.dokka:dokka-core", version.ref = "dokka" }
 dokka-gradle = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 
 dropbox-dependencyGuard = { module = "com.dropbox.dependency-guard:dependency-guard", version.ref = "dropbox-dependencyGuard" }


### PR DESCRIPTION
AGP is leaking an ancient version of Dokka, which is causing a `NoSuchMethodError` in Dokka 1.6.21+