### PR TITLE
Qualifier Annotation Fix

### DIFF
--- a/tangle-compiler/src/main/kotlin/tangle/inject/compiler/KotlinPoet.kt
+++ b/tangle-compiler/src/main/kotlin/tangle/inject/compiler/KotlinPoet.kt
@@ -116,7 +116,7 @@ fun List<AnnotationReference>.qualifierAnnotationSpecs(
     .find { it.fqName == FqNames.qualifier }
     ?: return@mapNotNull null
 
-  AnnotationSpec(qualifierAnnotation.classReference.asClassName()) {
+  AnnotationSpec(annotationReference.classReference.asClassName()) {
     qualifierAnnotation.arguments
       .forEach { arg ->
         when (val value = arg.value<Any>()) {

--- a/tangle-compiler/src/main/kotlin/tangle/inject/compiler/KotlinPoet.kt
+++ b/tangle-compiler/src/main/kotlin/tangle/inject/compiler/KotlinPoet.kt
@@ -22,7 +22,6 @@ import com.squareup.anvil.compiler.internal.classDescriptor
 import com.squareup.anvil.compiler.internal.fqNameOrNull
 import com.squareup.anvil.compiler.internal.reference.AnnotationArgumentReference
 import com.squareup.anvil.compiler.internal.reference.AnnotationReference
-import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.TypeReference
 import com.squareup.anvil.compiler.internal.reference.TypeReference.Descriptor
 import com.squareup.anvil.compiler.internal.reference.TypeReference.Psi
@@ -37,11 +36,9 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.jvm.jvmSuppressWildcards
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
-import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.resolve.constants.EnumValue
 import org.jetbrains.kotlin.resolve.constants.KClassValue
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
-import org.jetbrains.kotlin.utils.sure
 import java.io.ByteArrayOutputStream
 import kotlin.reflect.KClass
 
@@ -125,13 +122,16 @@ fun List<AnnotationReference>.qualifierAnnotationSpecs(
   AnnotationSpec(annotationReference.classReference.asClassName()) {
     annotationReference.arguments
       .forEach { arg ->
-        // TODO: Anvil's PSI Parsing for AnnotationArgumentReference.Psi currently does not fold
+        // Anvil's PSI Parsing for AnnotationArgumentReference.Psi currently does not fold
         //   constants within string templates correctly, instead always taking only the first leaf
         //   node. This causes an annotation like `@MyQualifier("Hello, $world")` to generate
         //   `@MyQualifier("Hello, ")`, which is obviously incorrect. This could be resolved here
         //   (in a separate PR) if desired, but it would be better to upstream the change.
         //   See: https://github.com/square/anvil/blob/main/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnnotationArgumentReference.kt#L267
-        if (arg is AnnotationArgumentReference.Psi && arg.argument.stringTemplateExpression?.hasInterpolation() == true) {
+        if (
+          arg is AnnotationArgumentReference.Psi &&
+          arg.argument.stringTemplateExpression?.hasInterpolation() == true
+        ) {
           throw TangleCompilationException(
             buildString {
               appendLine("String Interpolation in Qualifier Arguments is not currently supported")

--- a/tangle-compiler/src/main/kotlin/tangle/inject/compiler/KotlinPoet.kt
+++ b/tangle-compiler/src/main/kotlin/tangle/inject/compiler/KotlinPoet.kt
@@ -122,12 +122,8 @@ fun List<AnnotationReference>.qualifierAnnotationSpecs(
   AnnotationSpec(annotationReference.classReference.asClassName()) {
     annotationReference.arguments
       .forEach { arg ->
-        // Anvil's PSI Parsing for AnnotationArgumentReference.Psi currently does not fold
-        //   constants within string templates correctly, instead always taking only the first leaf
-        //   node. This causes an annotation like `@MyQualifier("Hello, $world")` to generate
-        //   `@MyQualifier("Hello, ")`, which is obviously incorrect. This could be resolved here
-        //   (in a separate PR) if desired, but it would be better to upstream the change.
-        //   See: https://github.com/square/anvil/blob/main/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnnotationArgumentReference.kt#L267
+        // Anvil 2.4.1 does not resolve constant-interpolated string templates correctly,
+        // this should be removed for the next version of Anvil
         if (
           arg is AnnotationArgumentReference.Psi &&
           arg.argument.stringTemplateExpression?.hasInterpolation() == true

--- a/tangle-fragment-api/src/test/kotlin/tangle/fragment/FragmentInjectGeneratorTest.kt
+++ b/tangle-fragment-api/src/test/kotlin/tangle/fragment/FragmentInjectGeneratorTest.kt
@@ -31,7 +31,6 @@ import tangle.inject.test.utils.myFragmentClass
 import tangle.inject.test.utils.myFragmentFactoryImplClass
 import tangle.inject.test.utils.newInstanceStatic
 import tangle.inject.test.utils.tangleUnitFragmentInjectModuleClass
-import tangle.inject.test.utils.tangleUnitFragmentModuleClass
 import tangle.inject.test.utils.tangleUnitFragmentModuleCompanionClass
 import javax.inject.Provider
 import kotlin.reflect.full.memberFunctions

--- a/tangle-fragment-compiler/src/main/kotlin/tangle/fragment/compiler/ContributesFragmentGenerator.kt
+++ b/tangle-fragment-compiler/src/main/kotlin/tangle/fragment/compiler/ContributesFragmentGenerator.kt
@@ -171,7 +171,11 @@ class ContributesFragmentGenerator : TangleCodeGenerator() {
                 argument.isWrappedInLazy -> argument.lazyTypeName
                 else -> argument.typeName
               }
-              addParameter(argument.name, paramType)
+              addParameter(
+                ParameterSpec.builder(argument.name, paramType)
+                  .applyEach(argument.qualifiers) { addAnnotation(it) }
+                  .build()
+              )
             }
             returns(binding.fragmentClassName)
             addStatement("return·%T.newInstance($args)", fragmentFactoryClassName)

--- a/tangle-fragment-compiler/src/main/kotlin/tangle/fragment/compiler/FragmentInject_ModuleGenerator.kt
+++ b/tangle-fragment-compiler/src/main/kotlin/tangle/fragment/compiler/FragmentInject_ModuleGenerator.kt
@@ -18,6 +18,7 @@ package tangle.fragment.compiler
 import com.squareup.anvil.compiler.api.GeneratedFile
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.TypeSpec
 import tangle.fragment.compiler.FragmentInject_ModuleGenerator.FragmentBindingModuleParams
 import tangle.inject.compiler.ClassNames
@@ -78,7 +79,11 @@ internal object FragmentInject_ModuleGenerator : FileGenerator<FragmentBindingMo
             ) {
               addAnnotation(ClassNames.provides)
               factoryConstructorParams.forEach { argument ->
-                addParameter(argument.name, argument.typeName.wrapInProvider())
+                addParameter(
+                  ParameterSpec.builder(argument.name, argument.typeName.wrapInProvider())
+                    .applyEach(argument.qualifiers) { addAnnotation(it) }
+                    .build()
+                )
               }
               returns(params.factoryInterfaceClassName)
               addStatement(

--- a/tangle-fragment-compiler/src/main/kotlin/tangle/fragment/compiler/Fragment_Factory_Generator.kt
+++ b/tangle-fragment-compiler/src/main/kotlin/tangle/fragment/compiler/Fragment_Factory_Generator.kt
@@ -20,7 +20,6 @@ import com.squareup.anvil.compiler.internal.capitalize
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
-import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec

--- a/tangle-fragment-compiler/src/main/kotlin/tangle/fragment/compiler/Fragment_Factory_Generator.kt
+++ b/tangle-fragment-compiler/src/main/kotlin/tangle/fragment/compiler/Fragment_Factory_Generator.kt
@@ -20,6 +20,7 @@ import com.squareup.anvil.compiler.internal.capitalize
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
@@ -110,13 +111,10 @@ internal object Fragment_Factory_Generator : FileGenerator<FragmentInjectParams.
         }
         .applyEach(factoryConstructorParams) { parameter ->
 
-          val qualifierAnnotationSpecs = parameter.qualifiers
-
           addProperty(
             PropertySpec.Companion.builder(parameter.name, parameter.providerTypeName)
               .initializer(parameter.name)
               .addModifiers(KModifier.INTERNAL)
-              .applyEach(qualifierAnnotationSpecs) { addAnnotation(it) }
               .build()
           )
         }

--- a/tangle-fragment-compiler/src/main/kotlin/tangle/fragment/compiler/Fragment_Factory_Generator.kt
+++ b/tangle-fragment-compiler/src/main/kotlin/tangle/fragment/compiler/Fragment_Factory_Generator.kt
@@ -110,10 +110,13 @@ internal object Fragment_Factory_Generator : FileGenerator<FragmentInjectParams.
         }
         .applyEach(factoryConstructorParams) { parameter ->
 
+          val qualifierAnnotationSpecs = parameter.qualifiers
+
           addProperty(
             PropertySpec.Companion.builder(parameter.name, parameter.providerTypeName)
               .initializer(parameter.name)
               .addModifiers(KModifier.INTERNAL)
+              .applyEach(qualifierAnnotationSpecs) { addAnnotation(it) }
               .build()
           )
         }

--- a/tangle-test-utils/src/main/kotlin/tangle/inject/test/utils/testUtils.kt
+++ b/tangle-test-utils/src/main/kotlin/tangle/inject/test/utils/testUtils.kt
@@ -122,4 +122,10 @@ fun Class<*>.annotationClasses() = annotations.map { it.annotationClass }
 fun <T : Any> KClass<T>.property(name: String) = memberProperties
   .first { it.name == name }
 
+fun <T> Any.propertyValue(name: String): T {
+  val property = this::class.property(name)
+  @Suppress("UNCHECKED_CAST")
+  return property.call(this) as T
+}
+
 fun Any.provider() = Provider { this }

--- a/tangle-test-utils/src/main/kotlin/tangle/inject/test/utils/testUtils.kt
+++ b/tangle-test-utils/src/main/kotlin/tangle/inject/test/utils/testUtils.kt
@@ -17,17 +17,13 @@ package tangle.inject.test.utils
 
 import com.tschuchort.compiletesting.KotlinCompilation.Result
 import dagger.internal.Factory
-import io.kotest.matchers.collections.shouldContain
 import org.jetbrains.kotlin.utils.addToStdlib.cast
 import java.lang.reflect.Executable
 import java.lang.reflect.Member
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
-import javax.inject.Inject
 import javax.inject.Provider
-import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KClass
-import kotlin.reflect.KFunction
 import kotlin.reflect.full.memberProperties
 
 val Member.isStatic: Boolean

--- a/tangle-test-utils/src/main/kotlin/tangle/inject/test/utils/testUtils.kt
+++ b/tangle-test-utils/src/main/kotlin/tangle/inject/test/utils/testUtils.kt
@@ -60,6 +60,7 @@ fun <T> T.factoryGet(): Any = cast<Factory<*>>().get()
 fun Result.appComponentFactoryCreate(
   vararg initargs: Any?
 ): Any {
+
   return daggerAppComponent.factoryFunction()
     .invoke(null)
     .invokeCreate(*initargs)

--- a/tangle-test-utils/src/main/kotlin/tangle/inject/test/utils/testUtils.kt
+++ b/tangle-test-utils/src/main/kotlin/tangle/inject/test/utils/testUtils.kt
@@ -69,16 +69,6 @@ fun Result.appComponentFactoryCreate(
     .invokeCreate(*initargs)
 }
 
-fun <T> Class<out T>.getInjectConstructor(): KFunction<T> =
-  kotlin.constructors.single { constructor ->
-    constructor.annotations.any { it.annotationClass == Inject::class }
-  }
-
-fun KFunction<*>.parameter(name: String) = parameters.single { it.name == name }
-
-infix fun KAnnotatedElement.shouldHaveAnnotation(annotation: KClass<*>) =
-  annotations.map { it.annotationClass } shouldContain annotation
-
 inline fun <T, E : Executable> E.use(block: (E) -> T): T {
   // Deprecated since Java 9, but many projects still use JDK 8 for compilation.
   @Suppress("DEPRECATION")

--- a/tangle-viewmodel-api/src/test/kotlin/tangle/viewmodel/VMInjectGeneratorTest.kt
+++ b/tangle-viewmodel-api/src/test/kotlin/tangle/viewmodel/VMInjectGeneratorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Rick Busarow
+ * Copyright (C) 2022 Rick Busarow
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -481,36 +481,6 @@ class VMInjectGeneratorTest : BaseTest() {
     val property: KProperty1<ViewModel, *> = instance::class.property("someArg").cast()
 
     property.get(instance) shouldBe expected
-  }
-
-  @TestFactory
-  fun `string interpolation error message`() = test {
-    compile(
-      """
-      package tangle.inject.test
-
-      import androidx.lifecycle.ViewModel
-      import tangle.viewmodel.VMInject
-      import javax.inject.Qualifier
-
-      @Qualifier
-      annotation class SomeQualifier(val value: String)
-
-      const val WORLD: String = "world!"
-
-      class Target @VMInject constructor(
-        @SomeQualifier("Hello, ${'$'}WORLD")
-        val qualified: String
-      ) : ViewModel()
-      """,
-      shouldFail = true
-    ) {
-      messages shouldContain """
-        String Interpolation in Qualifier Arguments is not currently supported
-        Here: "Hello, ${'$'}WORLD"
-        In: "@SomeQualifier("Hello, ${'$'}WORLD")"
-      """.trimIndent()
-    }
   }
 
   @Test

--- a/tangle-viewmodel-api/src/test/kotlin/tangle/viewmodel/VMInjectGeneratorTest.kt
+++ b/tangle-viewmodel-api/src/test/kotlin/tangle/viewmodel/VMInjectGeneratorTest.kt
@@ -48,6 +48,7 @@ class VMInjectGeneratorTest : BaseTest() {
       class Target @VMInject constructor() : ViewModel()
      """
     ) {
+
       provideTarget()::class.java shouldBe targetClass
     }
   }
@@ -193,13 +194,7 @@ class VMInjectGeneratorTest : BaseTest() {
      """
       ) {
         provideTarget(
-          Provider {
-            SavedStateHandle(
-              mapOf(
-                "aNameWhichIsVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong" to "Leeroy"
-              )
-            )
-          }
+          Provider { SavedStateHandle(mapOf("aNameWhichIsVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong" to "Leeroy")) }
         )::class.java shouldBe targetClass
       }
     }
@@ -517,7 +512,8 @@ class VMInjectGeneratorTest : BaseTest() {
     """,
     shouldFail = true
   ) {
-    messages shouldContain "[Dagger/MissingBinding] @tangle.inject.test.SomeQualifier java.lang.String cannot be provided without an @Provides-annotated method."
+    messages shouldContain "[Dagger/MissingBinding] @tangle.inject.test.SomeQualifier " +
+      "java.lang.String cannot be provided without an @Provides-annotated method."
   }
 
   fun Result.provideTarget(vararg args: Any?): Any {

--- a/tangle-viewmodel-api/src/test/kotlin/tangle/viewmodel/VMInjectGeneratorTest.kt
+++ b/tangle-viewmodel-api/src/test/kotlin/tangle/viewmodel/VMInjectGeneratorTest.kt
@@ -194,13 +194,7 @@ class VMInjectGeneratorTest : BaseTest() {
      """
       ) {
         provideTarget(
-          Provider {
-            SavedStateHandle(
-              mapOf(
-                "aNameWhichIsVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong" to "Leeroy"
-              )
-            )
-          }
+          Provider { SavedStateHandle(mapOf("aNameWhichIsVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong" to "Leeroy")) }
         )::class.java shouldBe targetClass
       }
     }

--- a/tangle-viewmodel-api/src/test/kotlin/tangle/viewmodel/VMInjectGeneratorTest.kt
+++ b/tangle-viewmodel-api/src/test/kotlin/tangle/viewmodel/VMInjectGeneratorTest.kt
@@ -193,11 +193,13 @@ class VMInjectGeneratorTest : BaseTest() {
      """
       ) {
         provideTarget(
-          Provider { SavedStateHandle(
-            mapOf(
-              "aNameWhichIsVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong" to "Leeroy"
+          Provider {
+            SavedStateHandle(
+              mapOf(
+                "aNameWhichIsVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong" to "Leeroy"
+              )
             )
-          ) }
+          }
         )::class.java shouldBe targetClass
       }
     }

--- a/tangle-viewmodel-api/src/test/kotlin/tangle/viewmodel/VMInjectGeneratorTest.kt
+++ b/tangle-viewmodel-api/src/test/kotlin/tangle/viewmodel/VMInjectGeneratorTest.kt
@@ -24,7 +24,6 @@ import org.jetbrains.kotlin.utils.addToStdlib.cast
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
 import tangle.inject.InternalTangleApi
-import tangle.inject.TangleGraph
 import tangle.inject.test.utils.BaseTest
 import tangle.inject.test.utils.appComponentFactoryCreate
 import tangle.inject.test.utils.property
@@ -194,7 +193,11 @@ class VMInjectGeneratorTest : BaseTest() {
      """
       ) {
         provideTarget(
-          Provider { SavedStateHandle(mapOf("aNameWhichIsVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong" to "Leeroy")) }
+          Provider { SavedStateHandle(
+            mapOf(
+              "aNameWhichIsVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong" to "Leeroy"
+            )
+          ) }
         )::class.java shouldBe targetClass
       }
     }
@@ -465,7 +468,7 @@ class VMInjectGeneratorTest : BaseTest() {
 
     @OptIn(InternalTangleApi::class)
     val instance: ViewModel =
-        appComponentFactoryCreate(expected, unexpected)
+      appComponentFactoryCreate(expected, unexpected)
         .cast<TangleViewModelComponent>()
         .tangleViewModelMapSubcomponentFactory
         .create(SavedStateHandle.createHandle(null, null))

--- a/tangle-viewmodel-api/src/test/kotlin/tangle/viewmodel/VMInjectGeneratorTest.kt
+++ b/tangle-viewmodel-api/src/test/kotlin/tangle/viewmodel/VMInjectGeneratorTest.kt
@@ -484,6 +484,36 @@ class VMInjectGeneratorTest : BaseTest() {
     property.get(instance) shouldBe expected
   }
 
+  @TestFactory
+  fun `string interpolation error message`() = test {
+    compile(
+      """
+      package tangle.inject.test
+
+      import androidx.lifecycle.ViewModel
+      import tangle.viewmodel.VMInject
+      import javax.inject.Qualifier
+
+      @Qualifier
+      annotation class SomeQualifier(val value: String)
+
+      const val WORLD: String = "world!"
+
+      class Target @VMInject constructor(
+        @SomeQualifier("Hello, ${'$'}WORLD")
+        val qualified: String
+      ) : ViewModel()
+      """,
+      shouldFail = true
+    ) {
+      messages shouldContain """
+        String Interpolation in Qualifier Arguments is not currently supported
+        Here: "Hello, ${'$'}WORLD"
+        In: "@SomeQualifier("Hello, ${'$'}WORLD")"
+      """.trimIndent()
+    }
+  }
+
   @Test
   fun `qualified argument without binding should fail`() = compileWithDagger(
     """

--- a/tangle-viewmodel-compiler/src/main/kotlin/tangle/viewmodel/compiler/ViewModelTangleScopeModuleGenerator.kt
+++ b/tangle-viewmodel-compiler/src/main/kotlin/tangle/viewmodel/compiler/ViewModelTangleScopeModuleGenerator.kt
@@ -21,6 +21,7 @@ import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.buildCodeBlock
 import tangle.inject.compiler.ClassNames
@@ -83,7 +84,13 @@ class ViewModelTangleScopeModuleGenerator : FileGenerator<TangleScopeModule> {
                 ) {
 
                   applyEach(factoryConstructorParams) { parameter ->
-                    addParameter(parameter.name, parameter.providerTypeName)
+                    addParameter(
+                      ParameterSpec.builder(parameter.name, parameter.providerTypeName)
+                        .applyEach(parameter.qualifiers) { annotation ->
+                          addAnnotation(annotation)
+                        }
+                        .build()
+                    )
                   }
 
                   returns(viewModelParams.viewModelClassName)

--- a/tangle-work-api/src/test/kotlin/tangle/work/WorkerFactoryGeneratorTest.kt
+++ b/tangle-work-api/src/test/kotlin/tangle/work/WorkerFactoryGeneratorTest.kt
@@ -18,15 +18,14 @@ package tangle.work
 import android.content.Context
 import androidx.work.WorkerParameters
 import hermit.test.mockk.resetsMockk
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.TestFactory
 import tangle.inject.test.utils.BaseTest
 import tangle.inject.test.utils.createInstance
-import tangle.inject.test.utils.getInjectConstructor
 import tangle.inject.test.utils.invokeCreate
 import tangle.inject.test.utils.invokeGet
-import tangle.inject.test.utils.parameter
-import tangle.inject.test.utils.shouldHaveAnnotation
+import javax.inject.Inject
 import javax.inject.Provider
 
 class WorkerFactoryGeneratorTest : BaseTest() {
@@ -310,13 +309,18 @@ class WorkerFactoryGeneratorTest : BaseTest() {
       }
     }
     """
-      ) {
-      val constructor = myWorker_AssistedFactoryClass.getInjectConstructor()
-
-      val annotationClasses = constructor.parameter("qualified")
+    ) {
       val clazz = classLoader.loadClass("tangle.inject.tests.SomeQualifier")
 
-      annotationClasses shouldHaveAnnotation clazz.kotlin
+      val constructor = myWorker_AssistedFactoryClass.kotlin.constructors
+        .single { constructor ->
+          constructor.annotations.any { it.annotationClass == Inject::class }
+        }
+
+      val annotationClasses = constructor.parameters.single { it.name == "qualified" }
+        .annotations.map { it.annotationClass }
+
+      annotationClasses shouldContain clazz.kotlin
     }
   }
 }

--- a/tangle-work-api/src/test/kotlin/tangle/work/WorkerFactoryGeneratorTest.kt
+++ b/tangle-work-api/src/test/kotlin/tangle/work/WorkerFactoryGeneratorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Rick Busarow
+ * Copyright (C) 2022 Rick Busarow
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -57,6 +57,7 @@ class WorkerFactoryGeneratorTest : BaseTest() {
     }
     """
     ) {
+
       val factory = myWorker_FactoryClass.createInstance()
       val assistedFactory = myWorker_AssistedFactoryClass.createInstance()
 
@@ -89,6 +90,7 @@ class WorkerFactoryGeneratorTest : BaseTest() {
     }
     """
     ) {
+
       val factory = myWorker_FactoryClass.createInstance()
       val assistedFactory = myWorker_AssistedFactoryClass.createInstance()
 
@@ -121,6 +123,7 @@ class WorkerFactoryGeneratorTest : BaseTest() {
     }
     """
     ) {
+
       val factory = myWorker_FactoryClass.createInstance()
       val assistedFactory = myWorker_AssistedFactoryClass.createInstance()
 
@@ -154,6 +157,7 @@ class WorkerFactoryGeneratorTest : BaseTest() {
     }
     """
     ) {
+
       val factory = myWorker_FactoryClass.createInstance(Provider { "string" })
       val assistedFactory = myWorker_AssistedFactoryClass.createInstance(Provider { "string" })
 
@@ -188,6 +192,7 @@ class WorkerFactoryGeneratorTest : BaseTest() {
     """,
       shouldFail = true
     ) {
+
       messages shouldContainIgnoringWhitespaces """
         @TangleWorker-annotated classes may only have Context and WorkerParameters as @Assisted-annotated parameters.
 
@@ -228,6 +233,7 @@ class WorkerFactoryGeneratorTest : BaseTest() {
     """,
       shouldFail = true
     ) {
+
       messages shouldContainIgnoringWhitespaces """
         @TangleWorker-annotated classes may only have Context and WorkerParameters as @Assisted-annotated parameters.
 
@@ -266,6 +272,7 @@ class WorkerFactoryGeneratorTest : BaseTest() {
     """,
       shouldFail = true
     ) {
+
       messages shouldContainIgnoringWhitespaces """
         @TangleWorker-annotated classes may only have Context and WorkerParameters as @Assisted-annotated parameters.
 

--- a/tangle-work-api/src/test/kotlin/tangle/work/WorkerFactoryGeneratorTest.kt
+++ b/tangle-work-api/src/test/kotlin/tangle/work/WorkerFactoryGeneratorTest.kt
@@ -25,7 +25,6 @@ import tangle.inject.test.utils.BaseTest
 import tangle.inject.test.utils.createInstance
 import tangle.inject.test.utils.invokeCreate
 import tangle.inject.test.utils.invokeGet
-import javax.inject.Inject
 import javax.inject.Provider
 
 class WorkerFactoryGeneratorTest : BaseTest() {
@@ -287,7 +286,7 @@ class WorkerFactoryGeneratorTest : BaseTest() {
   }
 
   @TestFactory
-  fun `qualified injected arguments are passed correctly`() = test {
+  fun `qualified inject parameter propagates qualifiers`() = test {
     compile(
       """
     package tangle.inject.tests
@@ -320,11 +319,10 @@ class WorkerFactoryGeneratorTest : BaseTest() {
       val clazz = classLoader.loadClass("tangle.inject.tests.SomeQualifier")
 
       val constructor = myWorker_AssistedFactoryClass.kotlin.constructors
-        .single { constructor ->
-          constructor.annotations.any { it.annotationClass == Inject::class }
-        }
+        .single()
 
-      val annotationClasses = constructor.parameters.single { it.name == "qualified" }
+      val annotationClasses = constructor.parameters
+        .single { it.name == "qualified" }
         .annotations.map { it.annotationClass }
 
       annotationClasses shouldContain clazz.kotlin

--- a/tangle-work-compiler/src/main/kotlin/tangle/work/compiler/AssistedWorkerFactoryGenerator.kt
+++ b/tangle-work-compiler/src/main/kotlin/tangle/work/compiler/AssistedWorkerFactoryGenerator.kt
@@ -20,11 +20,14 @@ import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.KModifier.PRIVATE
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.ParameterSpec.Companion
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import tangle.inject.compiler.ClassNames
 import tangle.inject.compiler.FileGenerator
+import tangle.inject.compiler.applyEach
 import tangle.inject.compiler.asArgumentList
 import tangle.inject.compiler.buildFile
 import java.io.File
@@ -55,7 +58,11 @@ object AssistedWorkerFactoryGenerator : FileGenerator<WorkerParams> {
                 addAnnotation(ClassNames.inject)
 
                 constructorParams.forEach { param ->
-                  addParameter(param.name, param.providerTypeName)
+                  addParameter(
+                    ParameterSpec.builder(param.name, param.providerTypeName)
+                      .applyEach(param.qualifiers) { addAnnotation(it) }
+                      .build()
+                  )
                 }
               }
                 .build()

--- a/tangle-work-compiler/src/main/kotlin/tangle/work/compiler/AssistedWorkerFactoryGenerator.kt
+++ b/tangle-work-compiler/src/main/kotlin/tangle/work/compiler/AssistedWorkerFactoryGenerator.kt
@@ -21,7 +21,6 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.ParameterSpec
-import com.squareup.kotlinpoet.ParameterSpec.Companion
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec


### PR DESCRIPTION
Currently, qualifier annotations on injected constructor params are not propagated to generated code at all.

### Proposed Changes

- Use the qualifier annotations during codegen to annotate injected parameters in modules
  - `ViewModel`s have this done in `ViewModelTangleScopeModuleGenerator`
  - `Fragment`s have this done in `ContributesFragmentGenerator` and `FragmentInject_ModuleGenerator`
  - Code for this has also been removed from `Fragment_Factory_Generator` as it was being applied in a non-`Inject` class
  - `Worker`s have this done in `AssistedWorkerFactoryGenerator`
- In `qualifierAnnotationSpecs` use the annotation reference itself to generate the annotation spec, instead of the `@Qualifier` it is annotated with.
- In `qualifierAnnotationSpec` use `resolvedName` instead of `name` for argument names, as `name` is null when the param is passed positionally.
- In `qualifierAnnotationSpec` wrap string and char values, so that they are correctly propogated
- In `qualifierAnnotationSpec` check whether an argument is an interpolated string, if so kill the compilation nicely.  
  This has to be done for now due to an oversight made in Anvil's `AnnotationArgumentReference.Psi`. I left a longer
  comment inline, but it should be technically feasible to do the constant folding required to make templates work on
  (at least) the happy path if that would be desirable. I am personally of the opinion that that kind of change should be
  upstreamed to anvil though.